### PR TITLE
Support for tailwind class based dark mode

### DIFF
--- a/src/battlechan_frontend/src/App.tsx
+++ b/src/battlechan_frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from "react";
+import React, { Suspense, lazy, useState, useEffect } from "react";
 import { PlugWallet} from "@connect2ic/core/providers";
 import { InternetIdentity} from "@connect2ic/core/providers";
 
@@ -17,15 +17,35 @@ const DashboardRoutes = lazy(() => import("./pages/Routes"));
 
 import Loader from "./components/Loader/Loader";
 
+type Theme = "dark" | "light";
+
 function App() {
+  const [theme, setTheme] = useState<Theme>("light")
   const [dark, setDark] = React.useState(false);
   const [light, setLight] = React.useState(true);
   const darkColor: string = dark ? "dark" : "light";
   const lightColor: string = !dark ? "dark" : "light";
 
+  useEffect(() => {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+      setTheme("dark");
+      setDark(true);
+      document.documentElement.classList.add("dark");
+    }
+  }, []);
+
   function handleThemeSwitch() {
     setDark(!dark);
     setLight(!light);
+    const newTheme = theme === "dark" ? "light" : "dark";
+    setTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+    if (newTheme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
   }
 
   return (

--- a/src/battlechan_frontend/src/components/Dashboard/UserProfile/UserProfile.tsx
+++ b/src/battlechan_frontend/src/components/Dashboard/UserProfile/UserProfile.tsx
@@ -19,7 +19,7 @@ const UserProfile = (props: Theme) => {
 
   return (
     <> 
-      <div  className={`min-h-lvh bg-[#ECECEC]`}>
+      <div className={`min-h-lvh bg-[#ECECEC] dark:bg-dark`}>
         {/* <Navbar darkColor={darkColor} lightColor={lightColor} />
       <NavButtons darkColor={darkColor} lightColor={lightColor} /> */}
 


### PR DESCRIPTION
Previously, we have to pass props to access the state of dark mode. but now we can use tailwinds dark: prefix to add dark mode styles. We can still use the conditional rendring based on dark mode state.
Added dark mode theme state to local storage so that the change in theme state remains persistent even after refreshing the page. 